### PR TITLE
support for k8s configmap reload

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -30,6 +30,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	yaml "gopkg.in/yaml.v2"
@@ -260,13 +261,14 @@ func (v *Viper) OnConfigChange(run func(in fsnotify.Event)) {
 
 func WatchConfig() { v.WatchConfig() }
 func (v *Viper) WatchConfig() {
+	wg := sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
 		watcher, err := fsnotify.NewWatcher()
 		if err != nil {
 			log.Fatal(err)
 		}
 		defer watcher.Close()
-
 		// we have to watch the entire directory to pick up renames/atomic saves in a cross-platform way
 		filename, err := v.getConfigFile()
 		if err != nil {
@@ -276,31 +278,46 @@ func (v *Viper) WatchConfig() {
 
 		configFile := filepath.Clean(filename)
 		configDir, _ := filepath.Split(configFile)
+		realConfigFile, _ := filepath.EvalSymlinks(filename)
 
 		done := make(chan bool)
 		go func() {
+			loop:
 			for {
 				select {
 				case event := <-watcher.Events:
-					// we only care about the config file
-					if filepath.Clean(event.Name) == configFile {
-						if event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create {
-							err := v.ReadInConfig()
-							if err != nil {
-								log.Println("error:", err)
-							}
+					currentConfigFile, _ := filepath.EvalSymlinks(filename)
+				// we only care about the config file with the following cases:
+				// 1 - if the config file was modified or created
+				// 2 - if the real path to the config file changed (eg: k8s ConfigMap replacement)
+					if (filepath.Clean(event.Name) == configFile &&
+						(event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create)) ||
+						(currentConfigFile != "" && currentConfigFile != realConfigFile) {
+						realConfigFile = currentConfigFile
+						err := v.ReadInConfig()
+						if err != nil {
+							log.Println("error reading file:", err.Error())
+						}
+						if v.onConfigChange != nil {
 							v.onConfigChange(event)
 						}
+					} else if filepath.Clean(event.Name) == configFile &&
+						event.Op&fsnotify.Remove == fsnotify.Remove {
+						done <- true
+						break loop
 					}
+
 				case err := <-watcher.Errors:
-					log.Println("error:", err)
+					log.Printf("watcher error: %v\n", err)
 				}
 			}
 		}()
-
 		watcher.Add(configDir)
-		<-done
+		wg.Done() // done initalizing the watch in this go routine, so the parent routine can move on...
+		<-done    // block until the watched file is removed...
 	}()
+	// make sure that the go routine above fully started before returning
+	wg.Wait()
 }
 
 // SetConfigFile explicitly defines the path, name and extension of the config file.
@@ -500,7 +517,7 @@ func (v *Viper) searchMapWithPathPrefixes(source map[string]interface{}, path []
 				// if the type of `next` is the same as the type being asserted
 				val = v.searchMapWithPathPrefixes(next.(map[string]interface{}), path[i:])
 			default:
-				// got a value but nested key expected, do nothing and look for next prefix
+			// got a value but nested key expected, do nothing and look for next prefix
 			}
 			if val != nil {
 				return val
@@ -1401,7 +1418,7 @@ func keyExists(k string, m map[string]interface{}) string {
 }
 
 func castToMapStringInterface(
-	src map[interface{}]interface{}) map[string]interface{} {
+src map[interface{}]interface{}) map[string]interface{} {
 	tgt := map[string]interface{}{}
 	for k, v := range src {
 		tgt[fmt.Sprintf("%v", k)] = v
@@ -1431,7 +1448,7 @@ func castMapFlagToMapInterface(src map[string]FlagValue) map[string]interface{} 
 // deep. Both map types are supported as there is a go-yaml fork that uses
 // `map[string]interface{}` instead.
 func mergeMaps(
-	src, tgt map[string]interface{}, itgt map[interface{}]interface{}) {
+src, tgt map[string]interface{}, itgt map[interface{}]interface{}) {
 	for sk, sv := range src {
 		tk := keyExists(sk, tgt)
 		if tk == "" {
@@ -1636,7 +1653,7 @@ func (v *Viper) flattenAndMergeMap(shadow map[string]bool, m map[string]interfac
 // shadowed by values from the first map.
 func (v *Viper) mergeFlatMap(shadow map[string]bool, m map[string]interface{}) map[string]bool {
 	// scan keys
-outer:
+	outer:
 	for k, _ := range m {
 		path := strings.Split(k, v.keyDelim)
 		// scan intermediate paths
@@ -1720,14 +1737,18 @@ func (v *Viper) getConfigType() string {
 }
 
 func (v *Viper) getConfigFile() (string, error) {
-	if v.configFile == "" {
-		cf, err := v.findConfigFile()
-		if err != nil {
-			return "", err
-		}
-		v.configFile = cf
+	// if explicitly set, then use it
+	if v.configFile != "" {
+		return v.configFile, nil
 	}
-	return v.configFile, nil
+
+	cf, err := v.findConfigFile()
+	if err != nil {
+		return "", err
+	}
+
+	v.configFile = cf
+	return v.getConfigFile()
 }
 
 func (v *Viper) searchInPath(in string) (filename string) {

--- a/viper_test.go
+++ b/viper_test.go
@@ -11,18 +11,23 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/afero"
 	"github.com/spf13/cast"
 
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var yamlExample = []byte(`Hacker: true
@@ -51,7 +56,6 @@ type testUnmarshalExtra struct {
 
 var tomlExample = []byte(`
 title = "TOML Example"
-
 [owner]
 organization = "MongoDB"
 Bio = "MongoDB Chief Developer Advocate & Hacker at Large"
@@ -852,26 +856,19 @@ var hclWriteExpected = []byte(`"foos" = {
   "foo" = {
     "key" = 1
   }
-
   "foo" = {
     "key" = 2
   }
-
   "foo" = {
     "key" = 3
   }
-
   "foo" = {
     "key" = 4
   }
 }
-
 "id" = "0001"
-
 "name" = "Cake"
-
 "ppu" = 0.55
-
 "type" = "donut"`)
 
 func TestWriteConfigHCL(t *testing.T) {
@@ -1365,6 +1362,104 @@ func doTestCaseInsensitive(t *testing.T, typ, config string) {
 	assert.Equal(t, 3, cast.ToInt(Get("ef.ijk")))
 	assert.Equal(t, 4, cast.ToInt(Get("ef.lm.no")))
 	assert.Equal(t, 5, cast.ToInt(Get("ef.lm.p.q")))
+
+}
+
+func newViperWithConfigFile(t *testing.T) (*Viper, string, func()) {
+	watchDir, err := ioutil.TempDir("", "")
+	require.Nil(t, err)
+	configFile := path.Join(watchDir, "config.yaml")
+	err = ioutil.WriteFile(configFile, []byte("foo: bar\n"), 0640)
+	require.Nil(t, err)
+	cleanup := func() {
+		os.RemoveAll(watchDir)
+	}
+	v := New()
+	v.SetConfigFile(configFile)
+	err = v.ReadInConfig()
+	require.Nil(t, err)
+	require.Equal(t, "bar", v.Get("foo"))
+	return v, configFile, cleanup
+}
+
+func newViperWithSymlinkedConfigFile(t *testing.T) (*Viper, string, string, func()) {
+	watchDir, err := ioutil.TempDir("", "")
+	require.Nil(t, err)
+	dataDir1 := path.Join(watchDir, "data1")
+	err = os.Mkdir(dataDir1, 0777)
+	require.Nil(t, err)
+	realConfigFile := path.Join(dataDir1, "config.yaml")
+	t.Logf("Real config file location: %s\n", realConfigFile)
+	err = ioutil.WriteFile(realConfigFile, []byte("foo: bar\n"), 0640)
+	require.Nil(t, err)
+	cleanup := func() {
+		os.RemoveAll(watchDir)
+	}
+	// now, symlink the tm `data1` dir to `data` in the baseDir
+	os.Symlink(dataDir1, path.Join(watchDir, "data"))
+	// and link the `<watchdir>/datadir1/config.yaml` to `<watchdir>/config.yaml`
+	configFile := path.Join(watchDir, "config.yaml")
+	os.Symlink(path.Join(watchDir, "data", "config.yaml"), configFile)
+	fmt.Printf("Config file location: %s\n", path.Join(watchDir, "config.yaml"))
+	// init Viper
+	v := New()
+	v.SetConfigFile(configFile)
+	err = v.ReadInConfig()
+	require.Nil(t, err)
+	require.Equal(t, "bar", v.Get("foo"))
+	return v, watchDir, configFile, cleanup
+}
+
+func TestWatchFile(t *testing.T) {
+	t.Run("file content changed", func(t *testing.T) {
+		// given a `config.yaml` file being watched
+		v, configFile, cleanup := newViperWithConfigFile(t)
+		defer cleanup()
+		wg := sync.WaitGroup{}
+		v.WatchConfig()
+		v.OnConfigChange(func(in fsnotify.Event) {
+			t.Logf("config file changed")
+			wg.Done()
+		})
+		wg.Add(1)
+		// when overwriting the file and waiting for the custom change notification handler to be triggered
+		err := ioutil.WriteFile(configFile, []byte("foo: baz\n"), 0640)
+		wg.Wait()
+		// then the config value should have changed
+		require.Nil(t, err)
+		assert.Equal(t, "baz", v.Get("foo"))
+	})
+
+	t.Run("link to real file changed (à la Kubernetes)", func(t *testing.T) {
+		// skip if not executed on Linux
+		if runtime.GOOS != "linux" {
+			t.Skipf("Skipping test as symlink replacements don't work on non-linux environment...")
+		}
+		v, watchDir, _, _ := newViperWithSymlinkedConfigFile(t)
+		// defer cleanup()
+		wg := sync.WaitGroup{}
+		v.WatchConfig()
+		v.OnConfigChange(func(in fsnotify.Event) {
+			t.Logf("config file changed")
+			wg.Done()
+		})
+		wg.Add(1)
+		// when link to another `config.yaml` file
+		dataDir2 := path.Join(watchDir, "data2")
+		err := os.Mkdir(dataDir2, 0777)
+		require.Nil(t, err)
+		configFile2 := path.Join(dataDir2, "config.yaml")
+		err = ioutil.WriteFile(configFile2, []byte("foo: baz\n"), 0640)
+		require.Nil(t, err)
+		// change the symlink using the `ln -sfn` command
+		err = exec.Command("ln", "-sfn", dataDir2, path.Join(watchDir, "data")).Run()
+		require.Nil(t, err)
+		wg.Wait()
+		// then
+		require.Nil(t, err)
+		assert.Equal(t, "baz", v.Get("foo"))
+
+	})
 
 }
 


### PR DESCRIPTION
```
[root@k8s-master examples]# kubectl -n kube-system exec -it kube-monkey-7b8987b4d8-9rmb2 sh
# cd /etc/kube-monkey
# ls -al
total 4
drwxrwxrwx.  3 root root   75 Apr  4 14:07 .
drwxr-xr-x. 43 root root 4096 Apr  4 09:42 ..
drwxr-xr-x.  2 root root   24 Apr  4 14:07 ..4984_04_04_14_07_49.707929309
lrwxrwxrwx.  1 root root   31 Apr  4 14:07 ..data -> ..4984_04_04_14_07_49.707929309
lrwxrwxrwx.  1 root root   18 Apr  4 09:42 config.toml -> ..data/config.toml

```